### PR TITLE
Cleanup code

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -26,10 +26,6 @@ func CopyBytes(src []byte, w *msgp.Writer) error {
 		return err
 	}
 
-	if err := w.Flush(); err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -41,15 +37,13 @@ func convertV(v *fastjson.Value, w *msgp.Writer) error {
 			return err
 		}
 
-		objV.Len()
-
 		err = w.WriteMapHeader(uint32(objV.Len()))
 		if err != nil {
 			return err
 		}
 
 		var visitErr error
-		objV.Visit(func(key []byte, v *fastjson.Value) {
+		objV.Visit(func(key []byte, vv *fastjson.Value) {
 			if visitErr != nil {
 				return
 			}
@@ -57,7 +51,7 @@ func convertV(v *fastjson.Value, w *msgp.Writer) error {
 			if err := w.WriteStringFromBytes(key); err != nil {
 				visitErr = err
 			}
-			if err := convertV(v, w); err != nil {
+			if err := convertV(vv, w); err != nil {
 				visitErr = err
 			}
 		})
@@ -72,8 +66,7 @@ func convertV(v *fastjson.Value, w *msgp.Writer) error {
 			return err
 		}
 
-		sz := uint32(len(items))
-		err = w.WriteArrayHeader(sz)
+		err = w.WriteArrayHeader(uint32(len(items)))
 		if err != nil {
 			return err
 		}

--- a/copy_test.go
+++ b/copy_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestCopyBytes(t *testing.T) {
 	// JSON data as bytes
-	src := []byte(`{"level": "debug", "event_timestamp": "2022-09-15T10:20:30Z", "msg": "the message", "caller": "the caller", "custom": "customVal", "array": ["foo", "bar"], "true": true, "false": false, "null": null}`)
+	src := []byte(`{"level": "debug", "event_timestamp": "2022-09-15T10:20:30Z", "msg": "the message", "caller": "the caller", "custom": "customVal", "array": ["foo", "bar"], "true": true, "false": false, "null": null, "float": 6.255089173237248, "number": 578}`)
 	buf := bytes.NewBuffer(make([]byte, 0, len(src)))
 	w := msgp.NewWriter(buf)
 


### PR DESCRIPTION
Good job on this tiny lib! I tried my best, but didn't manage to find what can be improved.

Also I checked a promising alternative to `fastjson`, i.e `jsoniter` which cockroachdb found to be [the best for their case](https://www.cockroachlabs.com/blog/high-performance-json-parsing/). But its `Iterator` doesn't support looking forward, so you don't know how long an array or an object is, which is crucial for messagepack.

Benchmark on main(old) vs this PR(new). The performance virtually didn't change:

```
goos: darwin
goarch: arm64
pkg: github.com/makasim/jsontomsgp
                  │     old     │                new                 │
                  │   sec/op    │   sec/op     vs base               │
CopyJSONToMsgp-10   421.8n ± 1%   415.1n ± 2%  -1.60% (p=0.000 n=30)
```